### PR TITLE
Silence react/no-did-update-set-state

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ module.exports = {
       'WithStatement',
     ],
     'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
+    'react/no-did-update-set-state': false,
     'no-param-reassign': [
       2,
       {


### PR DESCRIPTION
Noted in the [AirBnB style guide issues log](https://github.com/airbnb/javascript/issues/1875#issuecomment-409015549), in React 16+ it is safe to allow `setState` in `componentDidUpdate`. This also matches the suggestions made in the [React documentation](https://reactjs.org/docs/react-component.html#componentdidupdate).

> You may call setState() immediately in componentDidUpdate() but note that it must be wrapped in a condition.