### PR TITLE
Remove react hooks plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,30 +1,24 @@
 module.exports = {
   root: true,
-  extends: [
-    'airbnb-base',
-  ],
+  extends: ['airbnb-base'],
   overrides: [
     {
       files: ['**/*.ts', '**/*.tsx'],
       extends: [
         'airbnb-base',
         'airbnb-typescript/base',
-        'plugin:react-hooks/recommended',
       ],
       parser: '@typescript-eslint/parser',
       parserOptions: {
         project: './tsconfig.json'
       },
-      plugins: ['@typescript-eslint', 'react-hooks'],
+      plugins: ['@typescript-eslint'],
     },
     {
       files: ['**/*.js', '**/*.jsx'],
-      extends: [
-        'airbnb-base',
-        'plugin:react-hooks/recommended'
-      ],
+      extends: ['airbnb-base'],
       parser: '@babel/eslint-parser',
-      plugins: ['@babel', 'react-hooks'],
+      plugins: ['@babel'],
     }
   ],
   rules: {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "eslint-config-airbnb-typescript": "^17.1.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "^2.8.8"
   },
   "packageManager": "yarn@3.2.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-gasbuddy",
-  "version": "7.3.1",
+  "version": "7.4.0",
   "description": "Javascript and Typescript standards for GasBuddy",
   "main": "index.js",
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1152,7 +1152,6 @@ __metadata:
     eslint-config-airbnb-typescript: ^17.1.0
     eslint-plugin-import: ^2.29.1
     eslint-plugin-prettier: ^4.2.1
-    eslint-plugin-react-hooks: ^4.6.0
     prettier: ^2.8.8
   languageName: unknown
   linkType: soft
@@ -1219,15 +1218,6 @@ __metadata:
     eslint-config-prettier:
       optional: true
   checksum: b9e839d2334ad8ec7a5589c5cb0f219bded260839a857d7a486997f9870e95106aa59b8756ff3f37202085ebab658de382b0267cae44c3a7f0eb0bcc03a4f6d6
-  languageName: node
-  linkType: hard
-
-"eslint-plugin-react-hooks@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "eslint-plugin-react-hooks@npm:4.6.0"
-  peerDependencies:
-    eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
-  checksum: 23001801f14c1d16bf0a837ca7970d9dd94e7b560384b41db378b49b6e32dc43d6e2790de1bd737a652a86f81a08d6a91f402525061b47719328f586a57e86c3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Having the `react-hooks` plugin related configuration in this repo prevents node apps from correctly working with eslint, so it'd be best to migrate this to a package supporting web-apps with its own specialized configuration.